### PR TITLE
Fixes to reading and accepting invites

### DIFF
--- a/src/policies/aserto.tenant.account.Account.ListInvites.rego
+++ b/src/policies/aserto.tenant.account.Account.ListInvites.rego
@@ -1,4 +1,10 @@
 package aserto.tenant.account.Account.ListInvites
 
+default allowed = false
+
 # should always be able to read your own invites
-default allowed = true
+allowed {
+  u = input.user
+
+  u.id != ""
+}

--- a/src/policies/aserto.tenant.account.Account.ListInvites.rego
+++ b/src/policies/aserto.tenant.account.Account.ListInvites.rego
@@ -1,3 +1,4 @@
 package aserto.tenant.account.Account.ListInvites
 
+# should always be able to read your own invites
 default allowed = true

--- a/src/policies/aserto.tenant.profile.Profile.GetInvites.rego
+++ b/src/policies/aserto.tenant.profile.Profile.GetInvites.rego
@@ -1,4 +1,21 @@
 package aserto.tenant.profile.Profile.GetInvites
 
-# should always be able to read your invites
-default allowed = true
+default allowed = false
+
+# global role
+allowed {
+  u = input.user
+
+  some i
+  data.roles.roles[u.attributes.roles[i]].perms["aserto.tenant.profile.Profile.GetInvites"].allowed
+}
+
+# tenant context role
+allowed {
+  u = input.user
+  t = input.resource["Aserto-Tenant-Id"]
+  a = u.applications[t]
+
+  some i
+  data.roles.roles[a.roles[i]].perms["aserto.tenant.profile.Profile.GetInvites"].allowed
+}

--- a/src/policies/aserto.tenant.profile.Profile.RespondToInvite.rego
+++ b/src/policies/aserto.tenant.profile.Profile.RespondToInvite.rego
@@ -1,4 +1,10 @@
 package aserto.tenant.profile.Profile.RespondToInvite
 
+default allowed = false
+
 # should always be able to accept your invites
-default allowed = true
+allowed {
+  u = input.user
+
+  u.id != ""
+}


### PR DESCRIPTION
- ListInvites and RespondToInvite are allowed for any logged in user
- revert GetInvites changes, so the call is only allowed for configured roles